### PR TITLE
Remove geojsonlint

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,4 @@ Makefile
 .github
 ^revdep$
 ^codemeta\.json$
+^geojson\.Rproj$

--- a/.github/workflows/R-CMD-check-docker.yaml
+++ b/.github/workflows/R-CMD-check-docker.yaml
@@ -5,7 +5,7 @@ name: R-check-fedora
 jobs:
   R-CMD-check-docker:
     runs-on: ubuntu-latest
-    
+
     name: ${{ matrix.config.image }}-${{ matrix.config.gcc}}
 
     strategy:
@@ -13,25 +13,25 @@ jobs:
       matrix:
         config:
         - {image: "sckott/fedora-clang-devel-spatial", gcc: "10", rscript: "/opt/R-devel/bin/Rscript"}
-        
+
     container: ${{ matrix.config.image }}
-    
+
     steps:
-      - uses: actions/checkout@v1
-      
+      - uses: actions/checkout@v3
+
       - uses: r-lib/actions/setup-pandoc@master
-      
+
       - name: Set R_LIBS
         run: |
           export R_LIBS="$(${{ matrix.config.rscript }} -e 'cat(.libPaths()[1])')"
           echo "::set-env name=R_LIBS::$R_LIBS"
-      
+
       - name: Cache R packages
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ${{ env.R_LIBS }}
           key: ${{ runner.os }}-${{ matrix.config.image }}-${{ matrix.config.gcc }}-${{ hashFiles('DESCRIPTION') }}
-          
+
       - name: Install dependencies
         run: ${{ matrix.config.rscript }} -e "options(repos=c(CRAN='https://cloud.r-project.org/')); install.packages('remotes')" -e "options(repos=c(CRAN='https://cloud.r-project.org/')); remotes::install_deps(dependencies = TRUE)" -e "remotes::install_cran('rcmdcheck')"
 
@@ -40,7 +40,7 @@ jobs:
 
       - name: Upload check results
         if: failure()
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@main
         with:
           name: ${{ runner.os }}-${{ matrix.config.gcc }}
           path: check

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -24,13 +24,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
 
-      - uses: r-lib/actions/setup-pandoc@master
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-tinytex@master
+      - uses: r-lib/actions/setup-tinytex@v2
         if: contains(matrix.config.args, 'no-manual') == false
 
       - name: Query dependencies
@@ -88,7 +88,7 @@ jobs:
 
       - name: Upload check results
         if: failure()
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v2
         with:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: check

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Install system dependencies
         if: runner.os == 'Linux'
         run: |
-          sudo add-apt-repository -y ppa:cran/jq 
+          sudo add-apt-repository -y ppa:cran/jq
           sudo add-apt-repository -y ppa:ubuntugis/ppa
           sudo apt-get -y update
           sudo apt-get install -y --no-install-recommends \
@@ -74,7 +74,7 @@ jobs:
             netcdf-bin
 
       - name: Install dependencies
-        run: Rscript -e "install.packages('remotes')" -e "remotes::install_deps(dependencies = TRUE)" -e "remotes::install_cran('rcmdcheck')" -e "remotes::install_github('ropensci/geojsonlint')"
+        run: Rscript -e "install.packages('remotes')" -e "remotes::install_deps(dependencies = TRUE)" -e "remotes::install_cran('rcmdcheck')"
 
       - name: Session info
         run: |

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,15 +5,15 @@ Description: Classes for 'GeoJSON' to make working with 'GeoJSON' easier.
     Includes S3 classes for 'GeoJSON' classes with brief summary output,
     and a few methods such as extracting and adding bounding boxes,
     properties, and coordinate reference systems; working with 
-    newline delimited 'GeoJSON'; linting through the 'geojsonlint' 
-    package; and serializing to/from 'Geobuf' binary 'GeoJSON' 
+    newline delimited 'GeoJSON'; and serializing to/from 'Geobuf' binary 'GeoJSON' 
     format.
-Version: 0.3.4
+Version: 0.3.4.9001
 Authors@R: c(
-    person("Scott", "Chamberlain", role = c("aut", "cre"), 
+    person("Scott", "Chamberlain", role = c("aut"), 
         email = "myrmecocystus@gmail.com",
         comment = c(ORCID="0000-0003-1444-9135")),
-    person("Jeroen", "Ooms", role = "aut")
+    person("Jeroen", "Ooms", role = "aut"), 
+    person("Michael", "Sumner", role  = "cre", email = "mdsumner@gmail.com")
     )
 License: MIT + file LICENSE
 URL: https://docs.ropensci.org/geojson, https://github.com/ropensci/geojson
@@ -31,14 +31,13 @@ Imports:
     magrittr,
     lazyeval
 Suggests:
-    geojsonlint (>= 0.2.0),
     tibble,
     testthat,
     knitr,
     rmarkdown,
     sf,
     stringi
-RoxygenNote: 7.1.0
 X-schema.org-applicationCategory: Geospatial
 X-schema.org-keywords: geojson, geospatial, conversion, data, input-output, bbox, polygon, geobuf
 X-schema.org-isPartOf: https://ropensci.org
+RoxygenNote: 7.2.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 geojson dev
 ============
 
+* Now working in main branch, removed references to old trunk branch. 
+
 * Removed geojsonlint and all linting facilities and code. `linting_opts()` is deprecated. 
 
 * New maintainer Michael Sumner. 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+geojson dev
+============
+
+* Removed geojsonlint and all linting facilities and code. `linting_opts()` is deprecated. 
+
+* New maintainer Michael Sumner. 
+
+
 geojson 0.3.4
 =============
 

--- a/R/linting.R
+++ b/R/linting.R
@@ -3,60 +3,49 @@
 #' @export
 #' @param lint (logical) lint geojson or not. Default: \code{FALSE}
 #' @param method (character) method to use:
-#' 
+#'
 #' - hint - uses `geojsonlint::geojson_hint()`
 #' - lint - uses `geojsonlint::geojson_lint()`
 #' - validate - uses `geojsonlint::geojson_validate()`
-#' 
+#'
 #' @param error (logical) Throw an error on parse failure? If \code{TRUE}, then
 #' function returns \code{TRUE} on success, and stop with the error
 #' message on error. Default: \code{FALSE}
 #' @param suppress_pkgcheck_warnings (logical) Suppress warning when
 #' `geojsonlint` is not installed? Default: \code{FALSE}
-#' @details if you have \pkg{geojsonlint} installed, we can lint
-#' your GeoJSON inputs for you. If not, we skip that step.
-#'
-#' Note that even if you aren't linting your geojson with \pkg{geojsonlint},
-#' we still do some minimal checks.
-#' @examples
-#' linting_opts(lint = TRUE)
-#'
-#' linting_opts(lint = TRUE, method = "hint")
-#' linting_opts(lint = TRUE, method = "hint", error = TRUE)
-#' linting_opts(lint = TRUE, method = "lint")
-#' linting_opts(lint = TRUE, method = "lint", error = TRUE)
-#' linting_opts(lint = TRUE, method = "validate")
-#' linting_opts(lint = TRUE, method = "validate", error = TRUE)
+#' @details linting_opts was deprecated in 0.3.5
 linting_opts <- function(lint = FALSE, method = "hint", error = FALSE,
   suppress_pkgcheck_warnings = FALSE) {
-
-  if (!method %in% c('hint', 'lint', 'validate')) {
-    stop("method must be one of 'hint', 'lint', or 'validate'", call. = FALSE)
-  }
-  options(geojson.lint = lint)
-  method_fun <- switch(
-    method,
-    hint = 'geojsonlint::geojson_hint',
-    lint = 'geojsonlint::geojson_lint',
-    validate = 'geojsonlint::geojson_validate'
-  )
-  options(geojson.method = method_fun)
-  options(geojson.error = error)
-  options(geojson.suppress_pkgcheck_warnings = suppress_pkgcheck_warnings)
-
-  list(lint = lint, method = method, error = error, 
-    suppress_pkgcheck_warnings = suppress_pkgcheck_warnings)
+ .Deprecated()
+  invisible(NULL)
+  # if (!method %in% c('hint', 'lint', 'validate')) {
+  #   stop("method must be one of 'hint', 'lint', or 'validate'", call. = FALSE)
+  # }
+  # options(geojson.lint = lint)
+  # method_fun <- switch(
+  #   method,
+  #   hint = 'geojsonlint::geojson_hint',
+  #   lint = 'geojsonlint::geojson_lint',
+  #   validate = 'geojsonlint::geojson_validate'
+  # )
+  # options(geojson.method = method_fun)
+  # options(geojson.error = error)
+  # options(geojson.suppress_pkgcheck_warnings = suppress_pkgcheck_warnings)
+  #
+  # list(lint = lint, method = method, error = error,
+  #   suppress_pkgcheck_warnings = suppress_pkgcheck_warnings)
 }
 
-hint <- function(x) {
-  eval(parse(text = getOption("geojson.method")))(
-    x,
-    error = getOption("geojson.error")
-  )
-}
+# hint <- function(x) {
+#   eval(parse(text = getOption("geojson.method")))(
+#     x,
+#     error = getOption("geojson.error")
+#   )
+# }
 
 hint_geojson <- function(x) {
-  if (checkforpkg('geojsonlint')) {
-    if (getOption("geojson.lint")) hint(x)
-  }
+  # if (checkforpkg('geojsonlint')) {
+  #   if (getOption("geojson.lint")) hint(x)
+  # }
+  invisible(NULL)
 }

--- a/R/ndgeojson.R
+++ b/R/ndgeojson.R
@@ -1,5 +1,5 @@
 #' Read and write newline-delimited GeoJSON (GeoJSON text sequences)
-#' 
+#'
 #' There are various flavors of newline-delimited GeoJSON, all of which
 #' we aim to handle here. See Details for more.
 #'
@@ -8,43 +8,43 @@
 #' @param file (character) a file. not a connection. required.
 #' @param sep (character) a character separator to use in [writeLines()]
 #' @param txt text, a file, or a url. required.
-#' @param pagesize (integer) number of lines to read/write from/to the 
+#' @param pagesize (integer) number of lines to read/write from/to the
 #' connection per iteration
 #' @param verbose (logical) print messages. default: `TRUE`
-#' 
-#' @note **IMPORTANT**: `ngeo_read` for now only handles lines of geojson 
+#'
+#' @note **IMPORTANT**: `ngeo_read` for now only handles lines of geojson
 #' in your file that are either features or geometry objects (e.g., point,
 #' multipoint, polygon, multipolygon, linestring, multilinestring)
-#' 
+#'
 #' @details
-#' 
-#' - `ndgeo_write`: writes \pkg{geojson} package types as 
+#'
+#' - `ndgeo_write`: writes \pkg{geojson} package types as
 #' newline-delimited GeoJSON to a file
-#' - `ndgeo_read`: reads newline-delimited GeoJSON from a string, 
+#' - `ndgeo_read`: reads newline-delimited GeoJSON from a string,
 #' file, or URL into the appropriate geojson type
-#' 
-#' As an alternative to `ndgeo_read`, you can simply use 
-#' [jsonlite::stream_in()] to convert newline-delimited GeoJSON 
+#'
+#' As an alternative to `ndgeo_read`, you can simply use
+#' [jsonlite::stream_in()] to convert newline-delimited GeoJSON
 #' to a data.frame
-#' 
+#'
 #' @return a `geojson` class object
-#' @references Newline-delimited JSON has a few flavors. 
-#' The only difference between ndjson <http://ndjson.org/> and 
-#' JSON Lines <http://jsonlines.org/> I can tell is that the former 
+#' @references Newline-delimited JSON has a few flavors.
+#' The only difference between ndjson <http://ndjson.org/> and
+#' JSON Lines <http://jsonlines.org/> I can tell is that the former
 #' requires UTF-8 encoding, while the latter does not.
-#' 
-#' GeoJSON text sequences has a specification found at  
+#'
+#' GeoJSON text sequences has a specification found at
 #' <https://tools.ietf.org/html/rfc8142>. The spec states that:
-#' 
+#'
 #' - a GeoJSON text sequence is any number of GeoJSON RFC7946 texts
 #' - each line encoded in UTF-8 RFC3629
-#' - each line preceded by one ASCII RFC20 record separator (RS; "0x1e") 
+#' - each line preceded by one ASCII RFC20 record separator (RS; "0x1e")
 #' character
 #' - each line followed by a line feed (LF)
 #' - each JSON text MUST contain a single GeoJSON object as defined in RFC7946
-#' 
+#'
 #' See also the GeoJSON specification <https://tools.ietf.org/html/rfc7946>
-#' 
+#'
 #' @examples
 #' # featurecollection
 #' ## write
@@ -59,7 +59,7 @@
 #' ## read
 #' ndgeo_read(outfile)
 #' unlink(outfile)
-#' 
+#'
 #' # read from an existing file
 #' ## GeoJSON objects all of same type: Feature
 #' file <- system.file("examples", 'ndgeojson1.json', package = "geojson")
@@ -70,21 +70,21 @@
 #' ## GeoJSON objects of mixed type: Point, and Feature
 #' file <- system.file("examples", 'ndgeojson3.json', package = "geojson")
 #' ndgeo_read(file)
-#' 
+#'
 #' \dontrun{
 #' # read from a file
-#' url <- "https://raw.githubusercontent.com/ropensci/geojson/master/inst/examples/ndgeojson1.json"
+#' url <- "https://raw.githubusercontent.com/ropensci/geojson/main/inst/examples/ndgeojson1.json"
 #' f <- tempfile(fileext = ".geojsonl")
 #' download.file(url, f)
 #' x <- ndgeo_read(f)
 #' x
 #' unlink(f)
-#' 
+#'
 #' # read from a URL
-#' url <- "https://raw.githubusercontent.com/ropensci/geojson/master/inst/examples/ndgeojson1.json"
+#' url <- "https://raw.githubusercontent.com/ropensci/geojson/main/inst/examples/ndgeojson1.json"
 #' x <- ndgeo_read(url)
 #' x
-#' 
+#'
 #' # geojson text sequences from file
 #' file <- system.file("examples", 'featurecollection2.geojson',
 #'   package = "geojson")

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -1,5 +1,4 @@
 .onLoad <- function(libname, pkgname) { # nocov start
-  linting_opts()
 
   if (requireNamespace("sf", quietly = TRUE)) {
     setMethod("as.geojson", "sf", function(x) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -57,17 +57,7 @@ verify_class <- function(x, clss) {
   if (cl != clss) stop("object is not of type ", clss, call. = FALSE)
 }
 
-checkforpkg <- function(x) {
-  if (!requireNamespace(x, quietly = TRUE)) {
-    if (!getOption("geojson.suppress_pkgcheck_warnings")) {
-      warning(sprintf("'%s' not installed, skipping GeoJSON linting", x),
-        call. = FALSE)
-    }
-    invisible(FALSE)
-  } else {
-    invisible(TRUE)
-  }
-}
+
 
 cchar <- function(x) {
   gsub("\"", "", as.character(x))

--- a/README.Rmd
+++ b/README.Rmd
@@ -1,5 +1,7 @@
-geojson
-=======
+---
+output: github_document
+---
+
 
 ```{r echo=FALSE}
 library("knitr")
@@ -35,12 +37,14 @@ knitr::opts_chunk$set(
 )
 ```
 
-[![cran checks](https://cranchecks.info/badges/worst/geojson)](https://cranchecks.info/pkgs/geojson)
 [![R-check](https://github.com/ropensci/geojson/workflows/R-check/badge.svg)](https://github.com/ropensci/geojson/actions?query=workflow%3AR-check)
 [![R-check-fedora](https://github.com/ropensci/geojson/workflows/R-check-fedora/badge.svg)](https://github.com/ropensci/geojson/actions?query=workflow%3AR-check-fedora)
-[![codecov](https://codecov.io/gh/ropensci/geojson/branch/master/graph/badge.svg)](https://codecov.io/gh/ropensci/geojson)
+[![codecov](https://codecov.io/gh/ropensci/geojson/branch/main/graph/badge.svg)](https://codecov.io/gh/ropensci/geojson)
 [![rstudio mirror downloads](https://cranlogs.r-pkg.org/badges/geojson)](https://github.com/metacran/cranlogs.app)
 [![cran version](https://www.r-pkg.org/badges/version/geojson)](https://cran.r-project.org/package=geojson)
+
+# geojson
+
 
 `geojson` aims to deal only with geojson data, without requiring any of the
 `sp`/`rgdal`/`rgeos` stack.  That means this package is light weight.
@@ -244,7 +248,7 @@ to_geobuf(y)
 read nd-GeoJSON
 
 ```{r}
-url <- "https://raw.githubusercontent.com/ropensci/geojson/master/inst/examples/ndgeojson1.json"
+url <- "https://raw.githubusercontent.com/ropensci/geojson/main/inst/examples/ndgeojson1.json"
 f <- tempfile(fileext = ".geojsonl")
 download.file(url, f)
 x <- ndgeo_read(f, verbose = FALSE)
@@ -291,4 +295,4 @@ By participating in this project you agree to abide by its terms.
 [jqr]: https://github.com/ropensci/jqr
 [jq]: https://github.com/stedolan/jq
 [protolite]: https://github.com/jeroen/protolite
-[coc]: https://github.com/ropensci/geojson/blob/master/CODE_OF_CONDUCT.md
+[coc]: https://github.com/ropensci/geojson/blob/main/CODE_OF_CONDUCT.md

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 
-[![cran
-checks](https://cranchecks.info/badges/worst/geojson)](https://cranchecks.info/pkgs/geojson)
 [![R-check](https://github.com/ropensci/geojson/workflows/R-check/badge.svg)](https://github.com/ropensci/geojson/actions?query=workflow%3AR-check)
 [![R-check-fedora](https://github.com/ropensci/geojson/workflows/R-check-fedora/badge.svg)](https://github.com/ropensci/geojson/actions?query=workflow%3AR-check-fedora)
-[![codecov](https://codecov.io/gh/ropensci/geojson/branch/master/graph/badge.svg)](https://codecov.io/gh/ropensci/geojson)
+[![codecov](https://codecov.io/gh/ropensci/geojson/branch/main/graph/badge.svg)](https://codecov.io/gh/ropensci/geojson)
 [![rstudio mirror
 downloads](https://cranlogs.r-pkg.org/badges/geojson)](https://github.com/metacran/cranlogs.app)
 [![cran

--- a/README.md
+++ b/README.md
@@ -1,55 +1,54 @@
-geojson
-=======
 
-
-
-[![cran checks](https://cranchecks.info/badges/worst/geojson)](https://cranchecks.info/pkgs/geojson)
+[![cran
+checks](https://cranchecks.info/badges/worst/geojson)](https://cranchecks.info/pkgs/geojson)
 [![R-check](https://github.com/ropensci/geojson/workflows/R-check/badge.svg)](https://github.com/ropensci/geojson/actions?query=workflow%3AR-check)
 [![R-check-fedora](https://github.com/ropensci/geojson/workflows/R-check-fedora/badge.svg)](https://github.com/ropensci/geojson/actions?query=workflow%3AR-check-fedora)
 [![codecov](https://codecov.io/gh/ropensci/geojson/branch/master/graph/badge.svg)](https://codecov.io/gh/ropensci/geojson)
-[![rstudio mirror downloads](https://cranlogs.r-pkg.org/badges/geojson)](https://github.com/metacran/cranlogs.app)
-[![cran version](https://www.r-pkg.org/badges/version/geojson)](https://cran.r-project.org/package=geojson)
+[![rstudio mirror
+downloads](https://cranlogs.r-pkg.org/badges/geojson)](https://github.com/metacran/cranlogs.app)
+[![cran
+version](https://www.r-pkg.org/badges/version/geojson)](https://cran.r-project.org/package=geojson)
 
-`geojson` aims to deal only with geojson data, without requiring any of the
-`sp`/`rgdal`/`rgeos` stack.  That means this package is light weight.
+# geojson
 
-We've defined classes (`S3`) following the [GeoJSON spec][geojsonspec]. These
-classes sort of overlap with `sp`'s classes, but not really. There's also some
-overlap in GeoJSON classes with Well-Known Text (WKT) classes, but GeoJSON has a
-subset of WKT's classes.
+`geojson` aims to deal only with geojson data, without requiring any of
+the `sp`/`rgdal`/`rgeos` stack. That means this package is light weight.
 
-The package [geoops](https://github.com/ropenscilabs/geoops) supports manipulations on
-the classes defined in this package. This package is used within
-[geojsonio](https://github.com/ropensci/geojsonio) to make some tasks easier.
+We’ve defined classes (`S3`) following the [GeoJSON
+spec](https://tools.ietf.org/html/rfc7946). These classes sort of
+overlap with `sp`’s classes, but not really. There’s also some overlap
+in GeoJSON classes with Well-Known Text (WKT) classes, but GeoJSON has a
+subset of WKT’s classes.
+
+The package [geoops](https://github.com/ropenscilabs/geoops) supports
+manipulations on the classes defined in this package. This package is
+used within [geojsonio](https://github.com/ropensci/geojsonio) to make
+some tasks easier.
 
 ## Installation
 
 Stable CRAN version
 
-
-```r
+``` r
 install.packages("geojson")
 ```
 
 Dev version
 
-
-```r
+``` r
 remotes::install_github("ropensci/geojson")
 ```
 
-
-```r
+``` r
 library("geojson")
 ```
 
 ## geojson class
 
-Essentially a character string with S3 class `geojson` attached to make it
-easy to perform operations on
+Essentially a character string with S3 class `geojson` attached to make
+it easy to perform operations on
 
-
-```r
+``` r
 x <- "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[-99.74,32.45]},\"properties\":{}}]}"
 as.geojson(x)
 #> <geojson> 
@@ -61,8 +60,7 @@ as.geojson(x)
 
 ## geometrycollection
 
-
-```r
+``` r
 x <- '{
  "type": "GeometryCollection",
  "geometries": [
@@ -88,24 +86,21 @@ x <- '{
 
 get the string
 
-
-```r
+``` r
 y[[1]]
 #> [1] "{\n \"type\": \"GeometryCollection\",\n \"geometries\": [\n   {\n     \"type\": \"Point\",\n     \"coordinates\": [100.0, 0.0]\n   },\n   {\n     \"type\": \"LineString\",\n     \"coordinates\": [ [101.0, 0.0], [102.0, 1.0] ]\n   }\n  ]\n}"
 ```
 
 get the type
 
-
-```r
+``` r
 geo_type(y)
 #> [1] "GeometryCollection"
 ```
 
 pretty print the geojson
 
-
-```r
+``` r
 geo_pretty(y)
 #> {
 #>     "type": "GeometryCollection",
@@ -137,8 +132,7 @@ geo_pretty(y)
 
 write to disk
 
-
-```r
+``` r
 geo_write(y, f <- tempfile(fileext = ".geojson"))
 jsonlite::fromJSON(f, FALSE)
 #> $type
@@ -179,14 +173,11 @@ jsonlite::fromJSON(f, FALSE)
 #> [1] 1
 ```
 
-
-
 ## properties
 
 Add properties
 
-
-```r
+``` r
 x <- '{ "type": "LineString", "coordinates": [ [100.0, 0.0], [101.0, 1.0] ]}'
 res <- linestring(x) %>% feature() %>% properties_add(population = 1000)
 res
@@ -197,8 +188,7 @@ res
 
 Get a property
 
-
-```r
+``` r
 properties_get(res, property = 'population')
 #> 1000
 ```
@@ -207,8 +197,7 @@ properties_get(res, property = 'population')
 
 Add crs
 
-
-```r
+``` r
 crs <- '{
   "type": "name",
   "properties": {
@@ -246,8 +235,7 @@ z
 
 Get crs
 
-
-```r
+``` r
 crs_get(z)
 #> $type
 #> [1] "name"
@@ -261,8 +249,7 @@ crs_get(z)
 
 Add bbox
 
-
-```r
+``` r
 tt <- x %>% feature() %>% bbox_add()
 tt
 #> {
@@ -294,28 +281,24 @@ tt
 
 Get bbox
 
-
-```r
+``` r
 bbox_get(tt)
 #> [1] 100   0 101   1
 ```
 
+## geojson in data.frame’s
 
-## geojson in data.frame's
-
-
-```r
+``` r
 x <- '{ "type": "Point", "coordinates": [100.0, 0.0] }'
 (pt <- point(x))
 #> <Point> 
 #>   coordinates:  [100,0]
 ```
 
-
-```r
+``` r
 library("tibble")
 tibble(a = 1:5, b = list(pt))
-#> # A tibble: 5 x 2
+#> # A tibble: 5 × 2
 #>       a b             
 #>   <int> <list>        
 #> 1     1 <geopoint [1]>
@@ -325,8 +308,7 @@ tibble(a = 1:5, b = list(pt))
 #> 5     5 <geopoint [1]>
 ```
 
-
-```r
+``` r
 x <- '{ "type": "MultiLineString",
   "coordinates": [ [ [100.0, 0.0], [101.0, 1.0] ], [ [102.0, 2.0], [103.0, 3.0] ] ] }'
 (mls <- multilinestring(x))
@@ -336,10 +318,9 @@ x <- '{ "type": "MultiLineString",
 #>   coordinates:  [[[100,0],[101,1]],[[102,2],[103,3]]]
 ```
 
-
-```r
+``` r
 tibble(a = 1:5, b = list(mls))
-#> # A tibble: 5 x 2
+#> # A tibble: 5 × 2
 #>       a b             
 #>   <int> <list>        
 #> 1     1 <gmltlnst [1]>
@@ -349,10 +330,9 @@ tibble(a = 1:5, b = list(mls))
 #> 5     5 <gmltlnst [1]>
 ```
 
-
-```r
+``` r
 tibble(a = 1:5, b = list(pt), c = list(mls))
-#> # A tibble: 5 x 3
+#> # A tibble: 5 × 3
 #>       a b              c             
 #>   <int> <list>         <list>        
 #> 1     1 <geopoint [1]> <gmltlnst [1]>
@@ -364,12 +344,11 @@ tibble(a = 1:5, b = list(pt), c = list(mls))
 
 ## geobuf
 
-Geobuf is a compact binary encoding for geographic data
-using protocol buffers <https://github.com/mapbox/geobuf> (via the [protolite][])
-package.
+Geobuf is a compact binary encoding for geographic data using protocol
+buffers <https://github.com/mapbox/geobuf> (via the
+[protolite](https://github.com/jeroen/protolite)) package.
 
-
-```r
+``` r
 file <- system.file("examples/test.pb", package = "geojson")
 (json <- from_geobuf(file))
 #> {"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[102,0.5]},"id":999,"properties":{"prop0":"value0","double":0.0123,"negative_int":-100,"positive_int":100,"negative_double":-1.2345e+16,"positive_double":1.2345e+16,"null":null,"array":[1,2,3.1],"object":{"foo":[5,6,7]}},"blabla":{"foo":[1,1,1]}},{"type":"Feature","geometry":{"type":"LineString","coordinates":[[102,0],[103,-1.1],[104,-3],[105,1]]},"id":123,"properties":{"custom1":"test","prop0":"value0","prop1":0}},{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[100,0],[101,0],[101,1],[100,1],[100,0]],[[99,10],[101,0],[100,1],[99,10]]]},"id":"test-id","properties":{"prop0":"value0","prop1":{"this":"that"}},"custom1":"jeroen"},{"type":"Feature","geometry":{"type":"MultiPolygon","coordinates":[[[[102,2],[103,2],[103,3],[102,2]]],[[[100,0],[101,0],[101,1],[100,1],[100,0]],[[100.2,0.2],[100.2,0.8],[100.2,0.2]]]]}},{"type":"Feature","geometry":{"type":"GeometryCollection","geometries":[{"type":"Point","coordinates":[100,0]},{"type":"LineString","coordinates":[[101,0],[102,1]]},{"type":"MultiPoint","coordinates":[[100,0],[101,1]]},{"type":"MultiLineString","coordinates":[[[100,0],[101,1]],[[102,2],[103,3]]]},{"type":"MultiPolygon","coordinates":[[[[102,2],[103,2],[103,3],[102,3],[102,2]]],[[[100,0],[101,0],[101,1],[100,1],[100,0]],[[100.2,0.2],[100.8,0.2],[100.8,0.8],[100.2,0.8],[100.2,0.2]]]]}]}}]}
@@ -401,9 +380,8 @@ to_geobuf(y)
 
 read nd-GeoJSON
 
-
-```r
-url <- "https://raw.githubusercontent.com/ropensci/geojson/master/inst/examples/ndgeojson1.json"
+``` r
+url <- "https://raw.githubusercontent.com/ropensci/geojson/main/inst/examples/ndgeojson1.json"
 f <- tempfile(fileext = ".geojsonl")
 download.file(url, f)
 x <- ndgeo_read(f, verbose = FALSE)
@@ -417,18 +395,14 @@ x
 #>     Point / 2
 ```
 
-
-
 Write nd-GeoJSON
 
-One would think we could take the output of `ndego_read()` above
-and pass to `ndgeo_write()`. However, in this example, the json is too big
-for `jqr` to handle, the underlying parser tool. So here's a smaller 
+One would think we could take the output of `ndego_read()` above and
+pass to `ndgeo_write()`. However, in this example, the json is too big
+for `jqr` to handle, the underlying parser tool. So here’s a smaller
 example:
 
-
-
-```r
+``` r
 file <- system.file("examples", "featurecollection2.geojson",
   package = "geojson")
 str <- paste0(readLines(file), collapse = " ")
@@ -439,14 +413,11 @@ str <- paste0(readLines(file), collapse = " ")
 #>   features (1st 5):  Point, Point, Point
 ```
 
-
-```r
+``` r
 outfile <- tempfile(fileext = ".geojson")
 ndgeo_write(x, outfile)
 jsonlite::stream_in(file(outfile))
-#> 
- Found 3 records...
- Imported 3 records. Simplifying...
+#>  Found 3 records... Imported 3 records. Simplifying...
 #>      type id   properties.NOME
 #> 1 Feature  0 Sec de segunrança
 #> 2 Feature  1             Teste
@@ -467,17 +438,13 @@ jsonlite::stream_in(file(outfile))
 
 ## Meta
 
-* Please [report any issues or bugs](https://github.com/ropensci/geojson/issues).
-* License: MIT
-* Get citation information for `geojson` in R doing `citation(package = 'geojson')`
-* Please note that this project is released with a [Contributor Code of Conduct][coc].
-By participating in this project you agree to abide by its terms.
+- Please [report any issues or
+  bugs](https://github.com/ropensci/geojson/issues).
+- License: MIT
+- Get citation information for `geojson` in R doing
+  `citation(package = 'geojson')`
+- Please note that this project is released with a [Contributor Code of
+  Conduct](https://github.com/ropensci/geojson/blob/main/CODE_OF_CONDUCT.md).
+  By participating in this project you agree to abide by its terms.
 
 [![ropensci_footer](https://ropensci.org/public_images/github_footer.png)](https://ropensci.org)
-
-
-[geojsonspec]: https://tools.ietf.org/html/rfc7946
-[jqr]: https://github.com/ropensci/jqr
-[jq]: https://github.com/stedolan/jq
-[protolite]: https://github.com/jeroen/protolite
-[coc]: https://github.com/ropensci/geojson/blob/master/CODE_OF_CONDUCT.md

--- a/codemeta.json
+++ b/codemeta.json
@@ -217,8 +217,8 @@
     }
   ],
   "contIntegration": "https://travis-ci.org/ropensci/geojson",
-  "releaseNotes": "https://github.com/ropensci/geojson/blob/master/NEWS.md",
-  "readme": "https://github.com/ropensci/geojson/blob/master/README.md",
+  "releaseNotes": "https://github.com/ropensci/geojson/blob/main/NEWS.md",
+  "readme": "https://github.com/ropensci/geojson/blob/main/README.md",
   "fileSize": "1008.856KB",
   "applicationCategory": "Geospatial",
   "isPartOf": "https://ropensci.org",

--- a/geojson.Rproj
+++ b/geojson.Rproj
@@ -1,0 +1,22 @@
+Version: 1.0
+
+RestoreWorkspace: No
+SaveWorkspace: No
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+LineEndingConversion: Posix
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace

--- a/man/linting_opts.Rd
+++ b/man/linting_opts.Rd
@@ -32,19 +32,5 @@ message on error. Default: \code{FALSE}}
 GeoJSON Linting
 }
 \details{
-if you have \pkg{geojsonlint} installed, we can lint
-your GeoJSON inputs for you. If not, we skip that step.
-
-Note that even if you aren't linting your geojson with \pkg{geojsonlint},
-we still do some minimal checks.
-}
-\examples{
-linting_opts(lint = TRUE)
-
-linting_opts(lint = TRUE, method = "hint")
-linting_opts(lint = TRUE, method = "hint", error = TRUE)
-linting_opts(lint = TRUE, method = "lint")
-linting_opts(lint = TRUE, method = "lint", error = TRUE)
-linting_opts(lint = TRUE, method = "validate")
-linting_opts(lint = TRUE, method = "validate", error = TRUE)
+linting_opts was deprecated in 0.3.5
 }

--- a/man/ndgeo.Rd
+++ b/man/ndgeo.Rd
@@ -85,7 +85,7 @@ ndgeo_read(file)
 
 \dontrun{
 # read from a file
-url <- "https://raw.githubusercontent.com/ropensci/geojson/master/inst/examples/ndgeojson1.json"
+url <- "https://raw.githubusercontent.com/ropensci/geojson/main/inst/examples/ndgeojson1.json"
 f <- tempfile(fileext = ".geojsonl")
 download.file(url, f)
 x <- ndgeo_read(f)
@@ -93,7 +93,7 @@ x
 unlink(f)
 
 # read from a URL
-url <- "https://raw.githubusercontent.com/ropensci/geojson/master/inst/examples/ndgeojson1.json"
+url <- "https://raw.githubusercontent.com/ropensci/geojson/main/inst/examples/ndgeojson1.json"
 x <- ndgeo_read(url)
 x
 

--- a/tests/testthat/helper-geojson.R
+++ b/tests/testthat/helper-geojson.R
@@ -1,1 +1,0 @@
-invisible(geojson::linting_opts(suppress_pkgcheck_warnings = TRUE))

--- a/tests/testthat/test-as.geojson.R
+++ b/tests/testthat/test-as.geojson.R
@@ -1,6 +1,6 @@
 context("as.geojson - character to geojson")
 
-invisible(linting_opts(suppress_pkgcheck_warnings = TRUE))
+
 
 library("sp")
 

--- a/tests/testthat/test-bbox.R
+++ b/tests/testthat/test-bbox.R
@@ -1,6 +1,6 @@
 context("bbox_add")
 
-invisible(linting_opts(suppress_pkgcheck_warnings = TRUE))
+
 
 x <- '{ "type": "Polygon",
 "coordinates": [

--- a/tests/testthat/test-crs.R
+++ b/tests/testthat/test-crs.R
@@ -1,6 +1,6 @@
 context("crs_add")
 
-invisible(linting_opts(suppress_pkgcheck_warnings = TRUE))
+
 
 x <- '{ "type": "Polygon",
 "coordinates": [

--- a/tests/testthat/test-feature.R
+++ b/tests/testthat/test-feature.R
@@ -1,6 +1,6 @@
 context("feature")
 
-invisible(linting_opts(suppress_pkgcheck_warnings = TRUE))
+
 
 x <- '{ "type": "Point", "coordinates": [100.0, 0.0] }'
 pt <- point(x)
@@ -43,7 +43,7 @@ test_that("empty feature object works", {
 })
 
 test_that("feature fails well", {
-  expect_error(feature('{"type": "FooBar"}'), 
+  expect_error(feature('{"type": "FooBar"}'),
     "type must be one of")
 
   expect_error(feature('{"type": "LineString"}'), "keys not correct")
@@ -54,29 +54,3 @@ test_that("feature fails well", {
   expect_error(feature('{"type": "LineString", "coordinates": [1,s]}'),
                "invalid char in json text")
 })
-
-test_that("linestring fails well with geojson linting on", {
-  invisible(linting_opts(TRUE, method = "hint", error = TRUE, TRUE))
-
-  skip_if_not_installed("geojsonlint")
-
-  expect_error(feature('{"type":"Feature","coordinates":[]}'),
-            "Feature object cannot contain a \"coordinates\" member")
-
-  expect_error(feature('{"type":"Feature","properties":{}}'),
-               "\"geometry\" member required")
-
-  expect_error(feature('{"type":"Feature","properties":{},"geometry":{}}'),
-               "\"type\" member required")
-
-  expect_error(feature('{"type":"Feature","properties":{},"geometry":{"type":"Point"}}'),
-               "\"coordinates\" member required")
-
-  expect_error(feature('{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[]}}'),
-               "position must have 2 or more elements")
-
-  expect_error(feature('{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[a]}}'),
-               "invalid char in json text")
-})
-
-invisible(linting_opts())

--- a/tests/testthat/test-featurecollection.R
+++ b/tests/testthat/test-featurecollection.R
@@ -1,6 +1,6 @@
 context("featurecollection")
 
-invisible(linting_opts(suppress_pkgcheck_warnings = TRUE))
+
 
 file <- system.file("examples", "featurecollection2.geojson",
   package = "geojson")
@@ -54,17 +54,4 @@ test_that("featurecollection fails well", {
   expect_error(featurecollection(5), "no method for numeric")
 })
 
-test_that("featurecollection fails well with geojson linting on", {
-  invisible(linting_opts(TRUE, method = "hint", error = TRUE, TRUE))
 
-  skip_if_not_installed("geojsonlint")
-
-  expect_error(
-    featurecollection('{"type": "featurecollection", "coordinates": [[]]}'),
-    "Expected FeatureCollection but got featurecollection")
-  expect_error(
-    featurecollection('{"type": "FeatureCollection", "coordinates": [[]]}'),
-    "FeatureCollection object cannot contain a \"coordinates\" member")
-})
-
-invisible(linting_opts())

--- a/tests/testthat/test-geo_bbox.R
+++ b/tests/testthat/test-geo_bbox.R
@@ -1,6 +1,6 @@
 context("geo_bbox")
 
-invisible(linting_opts(suppress_pkgcheck_warnings = TRUE))
+
 
 test_that("geo_bbox works - Point input", {
   x <- '{ "type": "Point", "coordinates": [100.0, 0.0] }'

--- a/tests/testthat/test-geo_pretty.R
+++ b/tests/testthat/test-geo_pretty.R
@@ -1,6 +1,6 @@
 context("geo_pretty")
 
-invisible(linting_opts(suppress_pkgcheck_warnings = TRUE))
+
 
 pt <- point('{ "type": "Point", "coordinates": [100.0, 0.0] }')
 poly <- polygon('{ "type": "Polygon", "coordinates": [[ [100.0, 0.0], [100.0, 1.0], [101.0, 1.0], [101.0, 0.0], [100.0, 0.0] ]]}')

--- a/tests/testthat/test-geo_type.R
+++ b/tests/testthat/test-geo_type.R
@@ -1,6 +1,6 @@
 context("geo_type")
 
-invisible(linting_opts(suppress_pkgcheck_warnings = TRUE))
+
 
 pt <- point('{ "type": "Point", "coordinates": [100.0, 0.0] }')
 

--- a/tests/testthat/test-geo_write.R
+++ b/tests/testthat/test-geo_write.R
@@ -1,6 +1,6 @@
 context("geo_write")
 
-invisible(linting_opts(suppress_pkgcheck_warnings = TRUE))
+
 
 pt <- point('{ "type": "Point", "coordinates": [100.0, 0.0] }')
 poly <- polygon('{ "type": "Polygon", "coordinates": [[ [100.0, 0.0], [100.0, 1.0], [101.0, 1.0], [101.0, 0.0], [100.0, 0.0] ]]}')

--- a/tests/testthat/test-geobuf.R
+++ b/tests/testthat/test-geobuf.R
@@ -1,6 +1,6 @@
 context("geobuf methods")
 
-invisible(linting_opts(suppress_pkgcheck_warnings = TRUE))
+
 
 testpb <- system.file("examples/test.pb", package = "geojson")
 lineone <- system.file("examples/linestring_one.geojson", package = "geojson")

--- a/tests/testthat/test-geometrycollection.R
+++ b/tests/testthat/test-geometrycollection.R
@@ -1,6 +1,6 @@
 context("geometrycollection")
 
-invisible(linting_opts(suppress_pkgcheck_warnings = TRUE))
+
 
 x <- '{
  "type": "GeometryCollection",
@@ -26,7 +26,7 @@ test_that("geometrycollection object structure is correct", {
 })
 
 test_that("geometrycollection: character class input", {
-  file <- system.file("examples", "geometrycollection1.geojson", 
+  file <- system.file("examples", "geometrycollection1.geojson",
     package = "geojson")
   txt <- paste0(readLines(file), collapse="")
   aa <- geometrycollection(txt)
@@ -71,14 +71,3 @@ test_that("geometrycollection fails well", {
   expect_error(geometrycollection(5), "no method for numeric")
 })
 
-test_that("geometrycollection fails well with geojson linting on", {
-  invisible(linting_opts(TRUE, method = "hint", error = TRUE))
-
-  skip_if_not_installed("geojsonlint")
-
-  expect_error(
-    geometrycollection('{"type": "GeometryCollection", "coordinates":[]}'),
-    "\"geometries\" member required")
-})
-
-invisible(linting_opts())

--- a/tests/testthat/test-is.methods.R
+++ b/tests/testthat/test-is.methods.R
@@ -1,6 +1,6 @@
 context("is-methods")
 
-invisible(linting_opts(suppress_pkgcheck_warnings = TRUE))
+
 
 test_that("is-methods", {
   expect_is(is_generator, "function")
@@ -77,14 +77,14 @@ test_that("is-methods fail well", {
   expect_error(is.point("foobar"), "x must be of class 'geopoint'")
   expect_error(is.multipoint("foobar"), "x must be of class 'geomultipoint'")
   expect_error(is.linestring("foobar"), "x must be of class 'geolinestring'")
-  expect_error(is.multilinestring("foobar"), 
+  expect_error(is.multilinestring("foobar"),
     "x must be of class 'geomultilinestring'")
   expect_error(is.polygon("foobar"), "x must be of class 'geopolygon'")
-  expect_error(is.multipolygon("foobar"), 
+  expect_error(is.multipolygon("foobar"),
     "x must be of class 'geomultipolygon'")
   expect_error(is.feature("foobar"), "x must be of class 'geofeature'")
-  expect_error(is.featurecollection("foobar"), 
+  expect_error(is.featurecollection("foobar"),
     "x must be of class 'geofeaturecollection'")
-  expect_error(is.geometrycollection("foobar"), 
+  expect_error(is.geometrycollection("foobar"),
     "x must be of class 'geogeometrycollection'")
 })

--- a/tests/testthat/test-linestring.R
+++ b/tests/testthat/test-linestring.R
@@ -1,6 +1,6 @@
 context("linestring")
 
-invisible(linting_opts(suppress_pkgcheck_warnings = TRUE))
+
 
 stt <- '{ "type": "LineString", "coordinates": [ [100.0, 0.0], [101.0, 1.0] ] }'
 aa <- linestring(stt)
@@ -46,17 +46,3 @@ test_that("linestring fails well", {
 
   expect_error(linestring(5), "no method for numeric")
 })
-
-test_that("linestring fails well with geojson linting on", {
-  invisible(linting_opts(TRUE, method = "hint", error = TRUE))
-
-  skip_if_not_installed("geojsonlint")
-
-  expect_error(linestring('{"type": "LineString", "coordinates": []}'),
-            "a line needs to have two or more coordinates to be valid")
-
-  expect_error(linestring('{"type": "LineString", "coordinates": [1]}'),
-               "a line needs to have two or more coordinates to be valid")
-})
-
-invisible(linting_opts())

--- a/tests/testthat/test-multilinestring.R
+++ b/tests/testthat/test-multilinestring.R
@@ -1,6 +1,6 @@
 context("multilinestring")
 
-invisible(linting_opts(suppress_pkgcheck_warnings = TRUE))
+
 
 stt <- '{ "type": "MultiLineString",
     "coordinates": [ [ [100.0, 0.0], [101.0, 1.0] ], [ [102.0, 2.0], [103.0, 3.0] ] ] }'
@@ -61,14 +61,3 @@ test_that("multilinestring fails well", {
   expect_error(multilinestring('{"type": "MultiLineString", "coordinates": [1,s]}'),
                "invalid char in json text")
 })
-
-test_that("multilinestring fails well with geojson linting on", {
-  invisible(linting_opts(TRUE, method = "hint", error = TRUE))
-
-  skip_if_not_installed("geojsonlint")
-
-  expect_error(multilinestring('{"type": "MultiLineString", "coordinates": [[]]}'),
-               "a line needs to have two or more coordinates to be valid")
-})
-
-invisible(linting_opts())

--- a/tests/testthat/test-multipoint.R
+++ b/tests/testthat/test-multipoint.R
@@ -1,6 +1,6 @@
 context("multipoint")
 
-invisible(linting_opts(suppress_pkgcheck_warnings = TRUE))
+
 
 # spaces
 stt <- '{"type":"MultiPoint","coordinates":[[100.0,0.0],[101.0,1.0]]}'
@@ -53,17 +53,3 @@ test_that("multipoint fails well", {
 
   expect_error(multipoint(5), "no method for numeric")
 })
-
-test_that("multipoint fails well with geojson linting on", {
-  invisible(linting_opts(TRUE, method = "hint", error = TRUE))
-
-  skip_if_not_installed("geojsonlint")
-
-  expect_error(multipoint('{"type": "MultiPoint", "coordinates": [1]}'),
-               "position should be an array, is a number instead")
-
-  expect_error(multipoint('{"type": "MultiFart", "coordinates": []}'),
-               "The type MultiFart is unknown")
-})
-
-invisible(linting_opts())

--- a/tests/testthat/test-multipolygon.R
+++ b/tests/testthat/test-multipolygon.R
@@ -1,6 +1,6 @@
 context("multipolygon")
 
-invisible(linting_opts(suppress_pkgcheck_warnings = TRUE))
+
 
 # spaces
 stt <- '{ "type": "MultiPolygon",
@@ -78,17 +78,3 @@ test_that("multipolygon fails well", {
 
   expect_error(multipolygon(5), "no method for numeric")
 })
-
-test_that("multipolygon fails well with geojson linting on", {
-  invisible(linting_opts(TRUE, method = "hint", error = TRUE))
-
-  skip_if_not_installed("geojsonlint")
-
-  expect_error(multipolygon('{"type": "MultiPolygon", "coordinates": [1]}'),
-               "a number was found where a coordinate array should")
-
-  expect_error(multipolygon('{"type": "Multipolygon", "coordinates": []}'),
-               "Expected MultiPolygon")
-})
-
-invisible(linting_opts())

--- a/tests/testthat/test-ndgeo.R
+++ b/tests/testthat/test-ndgeo.R
@@ -1,6 +1,6 @@
 context("ndgeo_write")
 
-invisible(linting_opts(suppress_pkgcheck_warnings = TRUE))
+
 
 file <- system.file("examples", 'featurecollection2.geojson',
   package = "geojson")

--- a/tests/testthat/test-ndgeo.R
+++ b/tests/testthat/test-ndgeo.R
@@ -50,7 +50,7 @@ test_that("ndgeo_read: from file", {
 })
 
 test_that("ndgeo_read: from url", {
-  url <- "https://raw.githubusercontent.com/ropensci/geojson/master/inst/examples/ndgeojson1.json"
+  url <- "https://raw.githubusercontent.com/ropensci/geojson/main/inst/examples/ndgeojson1.json"
   aa <- ndgeo_read(url, verbose = FALSE)
 
   expect_is(aa, "geojson")

--- a/tests/testthat/test-point.R
+++ b/tests/testthat/test-point.R
@@ -1,6 +1,6 @@
 context("point")
 
-invisible(linting_opts(suppress_pkgcheck_warnings = TRUE))
+
 
 # spaces
 stt <- '{ "type": "Point", "coordinates": [100.0, 0.0] }'
@@ -58,21 +58,3 @@ test_that("point fails well", {
 
   expect_error(point(5), "no method for numeric")
 })
-
-test_that("point fails well with geojson linting on", {
-  invisible(linting_opts(TRUE, method = "hint", error = TRUE))
-
-  skip_if_not_installed("geojsonlint")
-
-  expect_error(point('{"type": "Point", "coordinates": []}'),
-               "position must have 2 or more elements")
-
-  expect_error(point('{"type": "Point", "coordinates": [1]}'),
-               "position must have 2 or more elements")
-
-  expect_error(point('{"type": "point", "coordinates": []}'),
-               "Expected Point")
-})
-
-invisible(linting_opts())
-

--- a/tests/testthat/test-polygon.R
+++ b/tests/testthat/test-polygon.R
@@ -1,6 +1,6 @@
 context("polygon")
 
-invisible(linting_opts(suppress_pkgcheck_warnings = TRUE))
+
 
 # spaces
 stt <- '{ "type": "Polygon",
@@ -64,23 +64,3 @@ test_that("polygon fails well", {
 
   expect_error(polygon(5), "no method for numeric")
 })
-
-test_that("polygon fails well with geojson linting on", {
-  invisible(linting_opts(TRUE, method = "hint", error = TRUE, TRUE))
-
-  skip_if_not_installed("geojsonlint")
-
-  expect_error(polygon('{"type": "Polygon", "coordinates": [[100.0,0.0],[101.0,0.0]]}'),
-               "a number was found where a coordinate array should have been found")
-
-  expect_error(polygon('{"type": "Polygon", "coordinates": [[]]}'),
-               "a number was found where a coordinate array should")
-
-  expect_error(polygon('{"type": "Polygon", "coordinates": [[1]]}'),
-               "a number was found where a coordinate array should")
-
-  expect_error(polygon('{"type": "polygon", "coordinates": [[]]}'),
-               "Expected Polygon")
-})
-
-invisible(linting_opts())

--- a/tests/testthat/test-properties.R
+++ b/tests/testthat/test-properties.R
@@ -1,6 +1,6 @@
 context("properties")
 
-invisible(linting_opts(suppress_pkgcheck_warnings = TRUE))
+
 
 test_that("properties_add works - value in fxn call", {
   x <- '{ "type": "LineString", "coordinates": [ [100.0, 0.0], [101.0, 1.0] ]}'

--- a/tests/testthat/test-stream_in_geojson.R
+++ b/tests/testthat/test-stream_in_geojson.R
@@ -1,6 +1,6 @@
 context("stream_in_geojson internal fxn")
 
-invisible(linting_opts(suppress_pkgcheck_warnings = TRUE))
+
 
 test_that("stream_in_geojson", {
   file <- system.file("examples", 'ndgeojson1.json', package = "geojson")
@@ -19,7 +19,7 @@ test_that("stream_in_geojson fails well", {
   z <- file(tempfile())
   w <- file(tempfile())
   expect_error(stream_in_geojson(z, 'foo'), "is not TRUE")
-  expect_error(stream_in_geojson(w, verbose = 'foo'), 
+  expect_error(stream_in_geojson(w, verbose = 'foo'),
     "is not TRUE")
   close(z)
   close(w)

--- a/tests/testthat/test-tibbles.R
+++ b/tests/testthat/test-tibbles.R
@@ -1,6 +1,6 @@
 context("tibble's work")
 
-invisible(linting_opts(suppress_pkgcheck_warnings = TRUE))
+
 
 test_that("tibbles work with multipolygon inputs", {
   x <- '{ "type": "MultiPolygon",

--- a/tests/testthat/test-to_geojson.R
+++ b/tests/testthat/test-to_geojson.R
@@ -1,6 +1,6 @@
 context("to_geojson")
 
-invisible(linting_opts(suppress_pkgcheck_warnings = TRUE))
+
 
 pt <- '{ "type": "Point", "coordinates": [100.0, 0.0] }'
 ls <- '{ "type": "LineString", "coordinates": [ [100.0, 0.0], [101.0, 1.0] ] }'


### PR DESCRIPTION
Removed geojsonlint from Suggests, tests, onLoad, and now refer to main branch. 

Haven't been careful with whitespace, it's just doing what rstudio does by default so there's a lot of whitespace updates

- [ ] need to fixup the gha yamls, I'm not clear what they should have re r-lib/actions@v2 etc 

maybe just recreate them from scratch

(if I make a mess of git, there's the original trunk that main cloned before this PR)
